### PR TITLE
Feature: additional 'Donation' option to link recurring 

### DIFF
--- a/CRM/SmartdebitReconciliation/Form/SmartdebitReconciliationList.php
+++ b/CRM/SmartdebitReconciliation/Form/SmartdebitReconciliationList.php
@@ -277,9 +277,11 @@ class CRM_SmartdebitReconciliation_Form_SmartdebitReconciliationList extends CRM
             $params = array( 1 => array( 10, 'Int' ), 2 => array(1, 'Int') );
             $dao = CRM_Core_DAO::executeQuery( $sql, $params);
             while ($dao->fetch()) {
+              $differences = 'Transaction: ' .$dao->reference_number. ' not Found in Civi';
               $regularAmount = substr($dao->regular_amount, 2);
               $transactionRecordFound = false;
               if (!empty($dao->contact_id)) {
+                $differences.= ' But Contact Found Using Smart Debit payerReference '. $dao->payerReference;
                 $missingContactID = $dao->contact_id;
                 $missingContactName = $dao->display_name;
                 $listArray[$dao->smart_debit_id]['fix_me_url']								= '/civicrm/smartdebit/reconciliation/fixmissingcivi?cid='.$dao->contact_id.'&reference_number='.$dao->reference_number;				
@@ -288,7 +290,6 @@ class CRM_SmartdebitReconciliation_Form_SmartdebitReconciliationList extends CRM
                 $missingContactName = $dao->first_name.' '.$dao->last_name;
                 $listArray[$dao->smart_debit_id]['fix_me_url']								= '/civicrm/smartdebit/reconciliation/fixmissingcivi?reference_number='.$dao->reference_number;									
               }
-              $differences = 'Transaction: ' .$dao->reference_number. ' not Found in Civi';
               $listArray[$dao->smart_debit_id]['recordFound']								= $transactionRecordFound;
               $listArray[$dao->smart_debit_id]['contact_id']								= $missingContactID;
               $listArray[$dao->smart_debit_id]['contact_name']							= $missingContactName;

--- a/CRM/SmartdebitReconciliation/Page/AJAX.php
+++ b/CRM/SmartdebitReconciliation/Page/AJAX.php
@@ -20,5 +20,30 @@ class CRM_SmartdebitReconciliation_Page_AJAX
         exit;
     } 
     
+    static function getNotLinkedRecurringByContactID() {
+      $selectedContact = CRM_Utils_Array::value( 'selectedContact', $_POST );
+      $mParams = array(
+                'version'     => 3,
+                'sequential'  => 1,
+                'contact_id' => $selectedContact
+              );
+      $aMembership = civicrm_api('Membership', 'get', $mParams);
+      $membershipWithRecur = array();
+      foreach ($aMembership['values'] as $membership ) {
+        if (!empty($membership['contribution_recur_id'])) {
+          $membershipWithRecur [] = $membership['contribution_recur_id'];
+        }
+      }
+      $allRecurringRecords = $originalAllRecurringRecords = CRM_SmartdebitReconciliation_Utils::get_Recurring_Record( $selectedContact );
+      foreach ($membershipWithRecur as $linkedRecur) {
+        if(array_key_exists($linkedRecur, $allRecurringRecords)) {
+          unset($allRecurringRecords[$linkedRecur]);
+        }
+      }
+      $options['cRecurNotLinked']     = $allRecurringRecords;
+      $options['cRecur']              = $originalAllRecurringRecords;
+      echo json_encode($options);
+        exit;
+    }
    
 }

--- a/CRM/SmartdebitReconciliation/Page/MembershipRecurDetails.php
+++ b/CRM/SmartdebitReconciliation/Page/MembershipRecurDetails.php
@@ -134,11 +134,13 @@ Class CRM_SmartdebitReconciliation_Page_MembershipRecurDetails extends CRM_Core_
         $this->assign('aContact', $contact);
         $this->assign('aAddress', $address);
       }
-      if(!empty($mid)){
+      // If 'Donation' option is choosen for membership, don't process
+      if(!empty($mid) && $mid != 'donation'){
        $membership = self::_get_membership($mid);
        $this->assign('aMembership', $membership);
       }
-      if(!empty($cr_id)){
+      // If 'Create New Recurring' option is choosen for recurring, don't process
+      if(!empty($cr_id) && $cr_id != 'new_recur'){
         $cRecur     = self::_get_contribution_recur($cr_id);
         $this->assign('aContributionRecur', $cRecur);
       }

--- a/CRM/SmartdebitReconciliation/Utils.php
+++ b/CRM/SmartdebitReconciliation/Utils.php
@@ -78,6 +78,7 @@ class CRM_SmartdebitReconciliation_Utils{
                              ); */
       $aMembershipOption[$mem_id] = $type.'/'.$status.'/'.$start_date.'/'.$end_date;
      }
+     $aMembershipOption['donation'] = 'Donation';
    return $aMembershipOption;
   }
   
@@ -110,6 +111,7 @@ class CRM_SmartdebitReconciliation_Utils{
       
       $cRecur[$ContributionRecur['id']] = $dao.'/'.$ContributionRecur['contribution_status'].'/'.$ContributionRecur['amount'];
     }
+    $cRecur['new_recur'] = 'Create New Recurring';
     return $cRecur;
   }
 }

--- a/templates/CRM/SmartdebitReconciliation/Form/MembershipRecurDetails.tpl
+++ b/templates/CRM/SmartdebitReconciliation/Form/MembershipRecurDetails.tpl
@@ -166,6 +166,37 @@
           cj('#contribution_recur_record').parents('tr').hide();
           cj('.crm-submit-buttons').hide();
       }
+      // When membership option is changed to 'Donation', show only recurring contributions which are not linked to memberships.
+      cj( "#membership_record" ).change(function() {
+        var val = cj('#membership_record option:selected').text();
+        var getTemplateContentUrl = {/literal}"{crmURL p='civicrm/ajax/rest' h=0 q='className=CRM_SmartdebitReconciliation_Page_AJAX&fnName=getNotLinkedRecurringByContactID&json=1'}"{literal} 
+        cj.ajax({
+          url : getTemplateContentUrl,
+          type: "POST",
+          data: {selectedContact: cid},
+          async: false,
+          datatype:"json",
+          success: function(data, status){
+            var options = cj.parseJSON(data);
+            if (val == 'Donation') {
+                var opRecur = options.cRecurNotLinked;
+                populateRecur(opRecur);
+            } else {
+                var opRecur = options.cRecur;
+                populateRecur(opRecur);
+            }
+          }
+        });
+      });
+      function populateRecur(opRecur) {
+        cj('#contribution_recur_record').find('option').remove();
+        cj.each(opRecur, function(crID, Recurtext) {
+          cj('#contribution_recur_record').append(cj('<option>', { 
+            value: crID,
+            text : Recurtext 
+           }));
+        });
+      }
     });
      {/literal}
   </script>


### PR DESCRIPTION
Feature: Added additional option called 'Donation' if don't want to pick up 'membership' in 'Fix Me' action and show only recurring which are not linked to membership

'Differences' column description changed  when accessing civicrm/smartdebit/reconciliation/list?checkMissingFromCivi=1 for contacts found using smart debit's payer reference but transaction id not found in civi
