### PR TITLE
New cron to refresh civicrm_sd_refresh table and added logs

### DIFF
--- a/CRM/SmartdebitReconciliation/Form/SmartdebitReconciliationList.php
+++ b/CRM/SmartdebitReconciliation/Form/SmartdebitReconciliationList.php
@@ -101,10 +101,6 @@ class CRM_SmartdebitReconciliation_Form_SmartdebitReconciliationList extends CRM
      * @return void
      */
     function buildQuickForm( ) {
-      // KJ 11/06/2015 To avoid get all records from smart debit when page loads by default
-      if (CRM_Utils_Array::value('runSmartDebitRefresh', $_GET)) {
-        $insertSmartDebit = self::insertSmartDebitToTable();
-      }
       
       // FOr smart debit sync purpose
         $sync = CRM_Utils_Array::value('sync', $_GET, '');
@@ -857,7 +853,7 @@ class CRM_SmartdebitReconciliation_Form_SmartdebitReconciliationList extends CRM
       return 0;
     }
     
-    function insertSmartDebitToTable() {
+    static function insertSmartDebitToTable() {
       // If no civicrm_sd, then create that table
       if(!CRM_Core_DAO::checkTableExists('civicrm_sd_refresh')) {
         $creatSql = "CREATE TABLE `civicrm_sd_refresh` (
@@ -892,8 +888,14 @@ class CRM_SmartdebitReconciliation_Form_SmartdebitReconciliationList extends CRM
       $emptySql = "TRUNCATE TABLE `civicrm_sd_refresh`";
       CRM_Core_DAO::executeQuery($emptySql);
     }
+    CRM_Core_Error::debug_var('CRM_SmartdebitReconciliation_Form_SmartdebitReconciliationList getSmartDebitPayments All', 'Started');
     $smartDebitArray = self::getSmartDebitPayments(NULL);
+    CRM_Core_Error::debug_var('CRM_SmartdebitReconciliation_Form_SmartdebitReconciliationList getSmartDebitPayments All', 'Ended');
     CRM_Core_Error::debug_var('smart debit array count', count($smartDebitArray));
+    CRM_Core_Error::debug_var('CRM_SmartdebitReconciliation_Form_SmartdebitReconciliationList Insert Into civicrm_sd_refresh table', 'Started');
+    if (empty($smartDebitArray)) {
+      return FALSE;
+    }
     foreach ($smartDebitArray as $key => $smartDebitRecord) {
       $sql = "INSERT INTO `civicrm_sd_refresh`(
             `title`,
@@ -939,5 +941,8 @@ class CRM_SmartdebitReconciliation_Form_SmartdebitReconciliationList extends CRM
      // CRM_Core_Error::debug_var('$params', $params);
       CRM_Core_DAO::executeQuery($sql, $params);
     }
+    CRM_Core_Error::debug_var('CRM_SmartdebitReconciliation_Form_SmartdebitReconciliationList Insert Into civicrm_sd_refresh table', 'Ended');
+    $mandateFetchedCount = count($smartDebitArray);
+    return $mandateFetchedCount;
   }
 }

--- a/CRM/SmartdebitReconciliation/Form/SmartdebitReconciliationList.php
+++ b/CRM/SmartdebitReconciliation/Form/SmartdebitReconciliationList.php
@@ -892,10 +892,10 @@ class CRM_SmartdebitReconciliation_Form_SmartdebitReconciliationList extends CRM
     $smartDebitArray = self::getSmartDebitPayments(NULL);
     CRM_Core_Error::debug_var('CRM_SmartdebitReconciliation_Form_SmartdebitReconciliationList getSmartDebitPayments All', 'Ended');
     CRM_Core_Error::debug_var('smart debit array count', count($smartDebitArray));
-    CRM_Core_Error::debug_var('CRM_SmartdebitReconciliation_Form_SmartdebitReconciliationList Insert Into civicrm_sd_refresh table', 'Started');
     if (empty($smartDebitArray)) {
       return FALSE;
     }
+    CRM_Core_Error::debug_var('CRM_SmartdebitReconciliation_Form_SmartdebitReconciliationList Insert Into civicrm_sd_refresh table', 'Started');
     foreach ($smartDebitArray as $key => $smartDebitRecord) {
       $sql = "INSERT INTO `civicrm_sd_refresh`(
             `title`,

--- a/README.md
+++ b/README.md
@@ -35,13 +35,11 @@
 
 <p dir="ltr" style="line-height:1.656;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-4b17e2cd-5577-e49e-c525-bbaae8554852"><span style="font-size: 14.6667px; font-family: Arial; color: rgb(0, 0, 0); vertical-align: baseline; white-space: pre-wrap;">1. Install </span><a href="https://github.com/veda-consulting/uk.co.vedaconsulting.module.smartdebit_reconciliation" style="text-decoration:none;"><span style="font-size: 14.6667px; font-family: Arial; color: rgb(17, 85, 204); text-decoration: underline; vertical-align: baseline; white-space: pre-wrap;">https://github.com/veda-consulting/uk.co.vedaconsulting.module.smartdebit_reconciliation </span></a><span style="font-size: 14.6667px; font-family: Arial; color: rgb(0, 0, 0); vertical-align: baseline; white-space: pre-wrap;">extension on your CiviCRM set up</span></span></p>
 
-<p>&nbsp;</p>
+<p>&nbsp;</p><p dir="ltr" style="line-height:1.656;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-4b17e2cd-5577-e49e-c525-bbaae8554852"><span style="font-size: 14.6667px; font-family: Arial; color: rgb(0, 0, 0); vertical-align: baseline; white-space: pre-wrap;">2. Have 'Refresh civicrm_sd_refresh table with latest Smart Debit Mandates' schedule job running</span></span></p>
 
-<p dir="ltr" style="line-height:1.656;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-4b17e2cd-5577-e49e-c525-bbaae8554852"><span style="font-size: 14.6667px; font-family: Arial; color: rgb(0, 0, 0); vertical-align: baseline; white-space: pre-wrap;">2. Access the extension (http://&lt;domain&gt;/civicrm/smartdebit/reconciliation/list)</span></span></p>
+<p dir="ltr" style="line-height:1.656;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-4b17e2cd-5577-e49e-c525-bbaae8554852"><span style="font-size: 14.6667px; font-family: Arial; color: rgb(0, 0, 0); vertical-align: baseline; white-space: pre-wrap;">3. Access the extension (http://&lt;domain&gt;/civicrm/smartdebit/reconciliation/list)</span></span></p>
 
 <p dir="ltr" style="line-height:1.656;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-4b17e2cd-5577-e49e-c525-bbaae8554852"><span style="font-size: 14.6667px; font-family: Arial; color: rgb(0, 0, 0); vertical-align: baseline; white-space: pre-wrap;"><img alt="home page.png" height="137" src="https://lh3.googleusercontent.com/Fjxrhr1fA_glxWiUqNDtN6By-mBCTOTdzmHFiLw7hEJVEe-BK3or4w8_O12LnJlPfdY4srVw-mLodgi92owqmKbcNSc8n7oeMLTwbdR_14fIQW7exOFkmbjLrKad0SAF7RKj8EQ" style="border: none; transform: rotate(0.00rad); -webkit-transform: rotate(0.00rad);" width="602" /></span></span></p>
-
-<p dir="ltr" style="line-height:1.656;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-4b17e2cd-5577-e49e-c525-bbaae8554852"><span style="font-size: 14.6667px; font-family: Arial; color: rgb(0, 0, 0); vertical-align: baseline; white-space: pre-wrap;">3. Pull all smart debit mandates to temp table (http://&lt;domain&gt;/civicrm/smartdebit/reconciliation/list?runSmartDebitRefresh=1)</span></span></p>
 
 <p>&nbsp;</p>
 

--- a/api/v3/Refreshsdmandatesincivi.mgd.php
+++ b/api/v3/Refreshsdmandatesincivi.mgd.php
@@ -1,0 +1,22 @@
+<?php
+// This file declares a managed database record of type "Job".
+// The record will be automatically inserted, updated, or deleted from the
+// database as appropriate. For more details, see "hook_civicrm_managed" at:
+// http://wiki.civicrm.org/confluence/display/CRMDOC42/Hook+Reference
+return array (
+  0 =>
+  array (
+    'name' => 'Cron:Smartdebitreconciliation.Refreshsdmandatesincivi',
+    'entity' => 'Job',
+    'params' =>
+    array (
+      'version' => 3,
+      'name' => 'Refresh civicrm_sd_refresh table with latest Smart Debit Mandates',
+      'description' => 'Refresh civicrm_sd_refresh table with latest Smart Debit Mandates',
+      'run_frequency' => 'Daily',
+      'api_entity' => 'Smartdebitreconciliation',
+      'api_action' => 'refreshsdmandatesincivi',
+      'parameters' => '',
+    ),
+  ),
+);

--- a/api/v3/Smartdebitreconciliation.php
+++ b/api/v3/Smartdebitreconciliation.php
@@ -1,0 +1,9 @@
+<?php
+function civicrm_api3_smartdebitreconciliation_refreshsdmandatesincivi($params) {
+  require_once 'CRM/SmartdebitReconciliation/Form/SmartdebitReconciliationList.php';
+  $mandateFetched = CRM_SmartdebitReconciliation_Form_SmartdebitReconciliationList::insertSmartDebitToTable();
+  if (empty($mandateFetched)) {
+    return civicrm_api3_create_error('No mandate fetched from smart debit');
+  }
+  return civicrm_api3_create_success(array('No of Records refreshed' => $mandateFetched), $params, 'Smartdebitreconciliation', 'refreshsdmandatesincivi');
+}

--- a/info.xml
+++ b/info.xml
@@ -15,8 +15,8 @@
     <author>Veda Consulting</author>
     <email>parvez@vedaconsulting.co.uk</email>
   </maintainer>
-  <releaseDate>2015-11-26</releaseDate>
-  <version>2.9.4</version>
+  <releaseDate>2016-07-08</releaseDate>
+  <version>2.9.5</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>4.6</ver>

--- a/templates/CRM/SmartdebitReconciliation/Form/SmartdebitReconciliationList.tpl
+++ b/templates/CRM/SmartdebitReconciliation/Form/SmartdebitReconciliationList.tpl
@@ -29,7 +29,6 @@
     <td>
       <div style="height:150px; overflow:auto;">
 	<p>
-	  <a href="{crmURL p='civicrm/smartdebit/reconciliation/list' q='runSmartDebitRefresh=1' h=0}">Run Smart Debit List</a><br />
 	  <a href="{crmURL p='civicrm/smartdebit/reconciliation/list' q='checkMissingFromCivi=1' h=0}">Show All Mandates Missing from CiviCRM</a><br />
 	  <a href="{crmURL p='civicrm/smartdebit/reconciliation/list' q='checkMissingFromSD=1' h=0}">Show All Mandates Missing from Smart Debit</a><br />
 	  <a href="{crmURL p='civicrm/smartdebit/reconciliation/list' q='checkAmount=1' h=0}">Show All Mandates with Differing Amounts</a><br />


### PR DESCRIPTION
new cron - 'Refresh civicrm_sd_refresh table with latest Smart Debit Mandate' to avoid same data dump api request being called different users at the same time
More logs added - before and after fetching, before and after inserting data in to civicrm_sd_refresh table

v2.9.5